### PR TITLE
M24H-64 adding a province to the actor model

### DIFF
--- a/malaria24/ona/migrations/0016_actor_province.py
+++ b/malaria24/ona/migrations/0016_actor_province.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ona', '0015_reportedcase_form'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='actor',
+            name='province',
+            field=models.CharField(blank=True, max_length=255, null=True, choices=[(b'EC', b'The Eastern Cape'), (b'FS', b'The Free State'), (b'GP', b'Gauteng'), (b'KZN', b'KwaZulu-Natal'), (b'LP', b'Limpopo'), (b'MP', b'Mpumalanga'), (b'NC', b'The Northern Cape'), (b'NW', b'North West'), (b'WC)', b'The Western Cape')]),
+        ),
+    ]

--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -189,6 +189,18 @@ class Actor(models.Model):
         (MANAGER_PROVINCIAL, 'Provincial Manager'),
         (MANAGER_NATIONAL, 'National Manager'),
     ], null=True, max_length=255)
+    province = models.CharField(
+        max_length=255, null=True, blank=True, choices=[
+            ('EC', 'The Eastern Cape'),
+            ('FS', 'The Free State'),
+            ('GP', 'Gauteng'),
+            ('KZN', 'KwaZulu-Natal'),
+            ('LP', 'Limpopo'),
+            ('MP', 'Mpumalanga'),
+            ('NC', 'The Northern Cape'),
+            ('NW', 'North West'),
+            ('WC)', 'The Western Cape'),
+        ])
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
Uses the full name as the display text and the province code as the
value stored in the db.
