### PR TITLE
M24H-42 send EP6 form as an attachment.

### DIFF
--- a/.deploy.yaml
+++ b/.deploy.yaml
@@ -13,3 +13,4 @@ dependencies:
   - libjpeg-dev
   - zlib1g-dev
   - gettext
+  - wkhtmltopdf

--- a/malaria24/ona/tasks.py
+++ b/malaria24/ona/tasks.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -88,7 +89,21 @@ def send_case_email(case_pk):
     recipients = [ehp.email_address for ehp in case.get_ehps()]
     msg = EmailMultiAlternatives(subject, text_content, from_email, recipients)
     msg.attach_alternative(html_content, "text/html")
+    msg.attach_alternative(make_pdf(html_content), "application/pdf")
     msg.send()
+
+
+def make_pdf(html_content):
+    print 'making PDF!!'
+    import pdfkit
+    import tempfile
+    fd, output_file = tempfile.mkstemp()
+    pdfkit.from_string(html_content, output_file)
+    with open(output_file, 'rb') as fp:
+        value = fp.read()
+    os.close(fd)
+    os.unlink(output_file)
+    return value
 
 
 @celery_app.task(ignore_result=True)

--- a/malaria24/ona/tasks.py
+++ b/malaria24/ona/tasks.py
@@ -93,8 +93,7 @@ def send_case_email(case_pk):
     msg.send()
 
 
-def make_pdf(html_content):
-    print 'making PDF!!'
+def make_pdf(html_content):  # pragma: no cover
     import pdfkit
     import tempfile
     fd, output_file = tempfile.mkstemp()

--- a/malaria24/ona/tasks.py
+++ b/malaria24/ona/tasks.py
@@ -78,12 +78,17 @@ def send_sms(to, content):
 
 @celery_app.task(ignore_result=True)
 def send_case_email(case_pk):
+    from django.core.mail import EmailMultiAlternatives
+
     case = ReportedCase.objects.get(pk=case_pk)
-    send_mail(subject='Malaria case number %s' % (case.case_number,),
-              message=case.get_text_email_content(),
-              from_email=settings.DEFAULT_FROM_EMAIL,
-              recipient_list=[ehp.email_address for ehp in case.get_ehps()],
-              html_message=case.get_html_email_content())
+    subject = 'Malaria case number %s' % (case.case_number,)
+    text_content = case.get_text_email_content()
+    html_content = case.get_html_email_content()
+    from_email = settings.DEFAULT_FROM_EMAIL
+    recipients = [ehp.email_address for ehp in case.get_ehps()]
+    msg = EmailMultiAlternatives(subject, text_content, from_email, recipients)
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()
 
 
 @celery_app.task(ignore_result=True)

--- a/malaria24/ona/tests/test_models.py
+++ b/malaria24/ona/tests/test_models.py
@@ -2,11 +2,13 @@ from django.core import mail
 from django.db.models.signals import post_save
 
 from testfixtures import LogCapture
+from mock import patch
 
 import responses
 
 from malaria24.ona.models import (
     ReportedCase, SMS, Digest, alert_new_case, MANAGER_DISTRICT, Facility)
+from malaria24.ona import tasks
 
 from .base import MalariaTestCase
 
@@ -45,8 +47,10 @@ class ReportedCaseTest(MalariaTestCase):
     def test_capture_no_reported_by(self):
         with LogCapture() as log:
             ehp = self.mk_ehp()
-            case = self.mk_case(facility_code=ehp.facility_code,
-                                reported_by='')
+            with patch.object(tasks, 'make_pdf') as mock_make_pdf:
+                mock_make_pdf.return_value = 'garbage for testing'
+                case = self.mk_case(facility_code=ehp.facility_code,
+                                    reported_by='')
             log.check(('root',
                        'WARNING',
                        ('Unable to SMS case number for case %s. '
@@ -56,7 +60,10 @@ class ReportedCaseTest(MalariaTestCase):
     def test_capture_all_ok(self):
         self.assertEqual(SMS.objects.count(), 0)
         ehp = self.mk_ehp()
-        case = self.mk_case(facility_code=ehp.facility_code)
+        with patch.object(tasks, 'make_pdf') as mock_make_pdf:
+            mock_make_pdf.return_value = 'garbage for testing'
+            case = self.mk_case(facility_code=ehp.facility_code)
+
         [ehp_sms, reporter_sms] = SMS.objects.all()
         self.assertEqual(ehp_sms.to, 'phone_number')
         self.assertEqual(ehp_sms.content,
@@ -75,8 +82,10 @@ class ReportedCaseTest(MalariaTestCase):
     def test_idempotency(self):
         self.assertEqual(SMS.objects.count(), 0)
         ehp = self.mk_ehp()
-        case = self.mk_case(facility_code=ehp.facility_code)
-        case.save()
+        with patch.object(tasks, 'make_pdf') as mock_make_pdf:
+            mock_make_pdf.return_value = 'garbage for testing'
+            case = self.mk_case(facility_code=ehp.facility_code)
+            case.save()
         self.assertEqual(SMS.objects.count(), 2)
 
     @responses.activate
@@ -87,14 +96,16 @@ class ReportedCaseTest(MalariaTestCase):
                                            subdistrict='The Subdistrict',
                                            province='The Province')
         ehp = self.mk_ehp(facility_code=facility.facility_code)
-        case = self.mk_case(facility_code=facility.facility_code)
+        with patch.object(tasks, 'make_pdf') as mock_make_pdf:
+            mock_make_pdf.return_value = 'garbage for testing'
+            case = self.mk_case(facility_code=facility.facility_code)
         [message] = mail.outbox
         self.assertEqual(message.subject,
                          'Malaria case number %s' % (case.case_number,))
         self.assertEqual(message.to, [ehp.email_address])
         self.assertTrue('does not support HTML' in message.body)
-        [alternative] = message.alternatives
-        content, content_type = alternative
+        [html_alternative, pdf_alternative] = message.alternatives
+        content, content_type = html_alternative
         self.assertTrue(case.facility_code in content)
         self.assertTrue(case.sa_id_number in content)
         self.assertTrue('The District' in content)
@@ -105,6 +116,8 @@ class ReportedCaseTest(MalariaTestCase):
         self.assertTrue(
             'http://example.com/static/ona/img/logo.png' in content)
         self.assertEqual('text/html', content_type)
+        self.assertEqual(('garbage for testing', 'application/pdf'),
+                         pdf_alternative)
 
     @responses.activate
     def test_age(self):

--- a/malaria24/ona/tests/test_views.py
+++ b/malaria24/ona/tests/test_views.py
@@ -6,7 +6,10 @@ from django.test.client import Client
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 
+from mock import patch
+
 from malaria24.ona.models import Facility
+from malaria24.ona import tasks
 from .base import MalariaTestCase
 
 import responses
@@ -90,7 +93,9 @@ class FacilityTest(MalariaTestCase):
             facility_code='123456',
             facility_name='The Old Name')
         self.mk_ehp(facility_code=facility.facility_code)
-        case = self.mk_case(facility_code=facility.facility_code)
+        with patch.object(tasks, 'make_pdf') as mock_make_pdf:
+            mock_make_pdf.return_value = 'garbage for testing'
+            case = self.mk_case(facility_code=facility.facility_code)
         response = self.client.get(reverse('admin:ehp_report_view', kwargs={
             'pk': case.pk,
         }))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ celery==3.1.18
 django-celery==3.1.16
 redis==2.10.3
 go_http==0.2.6
+pdfkit==0.5.0


### PR DESCRIPTION
Using pdfkit & wkhtmltopdf to turn the existing email template into a
PDF before sending.
