### PR TITLE
fix date mocking bug

### DIFF
--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -312,6 +312,9 @@ class ReportedCase(models.Model):
     ehps = models.ManyToManyField('Actor', blank=True)
     form = models.ForeignKey('OnaForm', null=True, blank=True)
 
+    def get_today(self):
+        return datetime.today()
+
     def get_facilities(self):
         return Facility.objects.filter(facility_code=self.facility_code)
 
@@ -340,7 +343,7 @@ class ReportedCase(models.Model):
     @property
     def age(self):
         "Returns the age of the patient"
-        today = datetime.today()
+        today = self.get_today()
         try:
             dob = datetime.strptime(self.date_of_birth, '%Y-%m-%d')
         except ValueError:

--- a/malaria24/ona/tests/test_models.py
+++ b/malaria24/ona/tests/test_models.py
@@ -350,8 +350,10 @@ class EhpReportedCaseTest(MalariaTestCase):
 
     @responses.activate
     def test_age(self):
-        case = self.mk_case(date_of_birth="1982-01-01")
-        self.assertEqual(33, case.age)
+        with patch.object(ReportedCase, 'get_today') as patch_today:
+            patch_today.return_value = datetime(2015, 01, 01)
+            case = self.mk_case(date_of_birth="1982-01-01")
+            self.assertEqual(33, case.age)
 
     @responses.activate
     def test_facility_name(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = F403
+ignore = F403,E402
 exclude = ve,migrations,local.py
 
 [pytest]


### PR DESCRIPTION
The date's not been mocked properly for the ReportedCase model tests, since we've gone past January the age of the patient in the test now returns 34 instead of 33. Mocking the date of the test ensures the age is always fixed for this test.
