### PR TITLE
Adds libraries to fix SSL support

### DIFF
--- a/.deploy.yaml
+++ b/.deploy.yaml
@@ -15,5 +15,7 @@ dependencies:
   - gettext
   - wkhtmltopdf
   - xvfb
+  - python-dev
+  - libssl-dev
 
   

--- a/malaria24/ona/tests/test_tasks.py
+++ b/malaria24/ona/tests/test_tasks.py
@@ -233,7 +233,7 @@ class OnaTest(MalariaTestCase):
     @responses.activate
     @override_settings(
         SMS_CHANNEL='JUNEBUG',
-        JUNEBUG_CHANNEL_URL='http://example.com/junebug/CHANNEL_ID')
+        JUNEBUG_CHANNEL_URL='https://example.com/junebug/CHANNEL_ID')
     def test_sms_junebug_if_set(self):
         """
         Checks sms sent via Junebug if that's what the setting specifies
@@ -244,7 +244,7 @@ class OnaTest(MalariaTestCase):
 
         responses.add(
             responses.POST,
-            ('http://example.com/junebug/CHANNEL_ID/messages/'),
+            ('https://example.com/junebug/CHANNEL_ID/messages/'),
             status=201, content_type='application/json',
             body=json.dumps({
                 "status": 201,
@@ -269,7 +269,7 @@ class OnaTest(MalariaTestCase):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "http://example.com/junebug/CHANNEL_ID/messages/")
+            "https://example.com/junebug/CHANNEL_ID/messages/")
         data = json.loads(responses.calls[0].request.body)
         self.assertEqual(data['event_url'], 'http://example.com/api/v1/event/')
         self.assertEqual(data['event_auth_token'], jb_token.key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ redis==2.10.3
 go_http==0.2.6
 pdfkit==0.5.0
 djangorestframework==3.3.2
+pyopenssl==17.5.0
+ndg-httpsclient==0.4.3
+pyasn1==0.4.2


### PR DESCRIPTION
Due to the older versions of python and ubuntu running on this machine a workaround needed to be implemented to enable SSL support.
This installs the necessary libraries to get things working