### PR TITLE
Feature/fix msisdn none normalization

### DIFF
--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -656,10 +656,14 @@ class ReportedCase(models.Model):
     form = models.ForeignKey('OnaForm', null=True, blank=True)
 
     def normalize_msisdn(self, mobile_number):
-        if re.match('^[+27]*([0-9]{9})$', mobile_number):
-            return mobile_number
-        else:
-            return '+27' + mobile_number[1:]
+        try:
+            msisdn = int(mobile_number)  # check if integer
+            if re.match('^[+27]*([0-9]{9})$', mobile_number):
+                return mobile_number
+            else:
+                return '+27' + mobile_number[1:]
+        except ValueError:
+            return mobile_number.lower()  # convert to lower case
 
     def get_data(self):
             '''JSON Formats need create_date_time & date_of_birth

--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -657,7 +657,7 @@ class ReportedCase(models.Model):
 
     def normalize_msisdn(self, mobile_number):
         try:
-            msisdn = int(mobile_number)  # check if integer
+            int(mobile_number)  # check if integer
             if re.match('^[+27]*([0-9]{9})$', mobile_number):
                 return mobile_number
             else:

--- a/malaria24/ona/tests/test_tasks.py
+++ b/malaria24/ona/tests/test_tasks.py
@@ -443,7 +443,7 @@ class OnaTest(MalariaTestCase):
                             msisdn="0711111111", landmark_description="None",
                             id_type="said", case_number="20171214-123456-42",
                             abroad="No", locality="None",
-                            reported_by="07722222222",
+                            reported_by="0722222222",
                             sa_id_number="5608071111083",
                             landmark="School", facility_code="123456",
                             date_of_birth="1995-01-01")
@@ -451,7 +451,22 @@ class OnaTest(MalariaTestCase):
         msisdn = case.normalize_msisdn(case.msisdn)
         reported_by = case.normalize_msisdn(case.reported_by)
         self.assertEqual(msisdn, '+27711111111')
-        self.assertEqual(reported_by, '+277722222222')
+        self.assertEqual(reported_by, '+27722222222')
+
+    @responses.activate
+    def test_none_type_msisdn_compile_data(self):
+        case = self.mk_case(first_name="John", last_name="Day", gender="male",
+                            msisdn="nONe", landmark_description="None",
+                            id_type="said", case_number="20171214-123456-42",
+                            abroad="No", locality="None",
+                            reported_by="0722222222",
+                            sa_id_number="5608071111083",
+                            landmark="School", facility_code="123456")
+        case.save()
+        msisdn = case.normalize_msisdn(case.msisdn)
+        reported_by = case.normalize_msisdn(case.reported_by)
+        self.assertEqual(msisdn, 'none')
+        self.assertEqual(reported_by, '+27722222222')
 
     @responses.activate
     def test_compile_and_send_jembi(self):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
-pytest==3.6
-pytest-django
-pytest-cov
-pytest-xdist
+pytest==3.6.3
+pytest-cov==2.5.1
+pytest-django==3.3.2
+pytest-forked==0.2
+pytest-xdist==1.22.2
 flake8==2.5.5
 responses
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyopenssl==17.5.0
 ndg-httpsclient==0.4.3
 pyasn1==0.4.2
 requests
+django-taggit==0.22.2


### PR DESCRIPTION
User case:
1. Jembi will be adding the requirement to allow the value "none" for MSISDN. 
2. On our side we need allow for "none" in the MSISDN field & not normalize it to "+27one". 
3. There is currently validation in place on the front end for MSISDN, ie. only valid MSISDNs are accepted along with all *case* variations of the word "none" (NONE,None,nOnE,noNE etc), and no other freetext values, eg "no ne" or "n0ne" generates a warning/redirect to the user. 
4. A thing to note here is that the "none" value is sent to Jembi in the format inputted by the user, so we need to add additional normalization to only send it to them in lowercase.