### PR TITLE
Pin markdown in the requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 django-compressor<1.6
 django-modelcluster==3.1
 django-taggit==0.18.0
+markdown==2.6.5
 molo.core==2.4.4
 celery==3.1.18
 django-celery==3.1.16


### PR DESCRIPTION
Markdown has been upgraded to version 3 however that version breaks some of the ussd api stuff that malaria_24 does. The error is on this sentry log: https://sentry.io/organizations/malaria-connect/issues/918495188/?project=1041049&query=is%3Aunresolved&statsPeriod=14d&utc=true
Pinning Markdown to version two helps resolve the issue