### PR TITLE
changed that sa_id_number be an empty string if found as none

### DIFF
--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -670,7 +670,8 @@ class ReportedCase(models.Model):
             to be overridden
 
             need to validate msisdn and reported_by fields are in
-            correct format'''
+            correct format
+            if sa_id_number is None, needs to return empty string'''
 
             try:
                 birth_date = datetime.strptime(self.date_of_birth, '%Y-%m-%d')
@@ -684,6 +685,12 @@ class ReportedCase(models.Model):
             reported_by = self.normalize_msisdn(self.reported_by)
             msisdn = self.normalize_msisdn(self.msisdn)
 
+            try:
+                int(self.sa_id_number)  # check if integer
+                sa_id_number = self.sa_id_number
+            except ValueError:
+                sa_id_number = ""
+
             return {"first_name": self.first_name,
                     "last_name": self.last_name,
                     "gender": self.gender,
@@ -695,7 +702,7 @@ class ReportedCase(models.Model):
                     "locality": self.locality,
                     "reported_by": reported_by,
                     "date_of_birth": birth_date.strftime("%Y-%m-%d"),
-                    "sa_id_number": self.sa_id_number,
+                    "sa_id_number": sa_id_number,
                     "create_date_time": self.create_date_time.strftime(
                         "%Y%m%d%H%M%S"),
                     "landmark": self.landmark,

--- a/malaria24/ona/tests/test_tasks.py
+++ b/malaria24/ona/tests/test_tasks.py
@@ -438,6 +438,22 @@ class OnaTest(MalariaTestCase):
         self.assertEqual(data['msisdn'], '+27711111111')
         self.assertEqual(data['reported_by'], '+27722222222')
 
+    @responses.activate
+    def test_get_data_for_none_sa_id_number(self):
+        '''if id_type = none, and sa_id_number set as none,
+        sa_id_number need to be converted to empty string'''
+        case = self.mk_case(first_name="John", last_name="Day", gender="male",
+                            msisdn="0711111111", landmark_description="None",
+                            id_type="none", case_number="20171214-123456-42",
+                            abroad="No", locality="None",
+                            reported_by="+27722222222",
+                            sa_id_number="None",
+                            landmark="School", facility_code="123456",
+                            date_of_birth="1995-01-01")
+        case.save()
+        data = case.get_data()
+        self.assertEqual(data['sa_id_number'], '')
+
     def test_normalize_msisdn(self):
         case = self.mk_case(first_name="John", last_name="Day", gender="male",
                             msisdn="0711111111", landmark_description="None",


### PR DESCRIPTION
In this PR, we are amend that when "id_type"="none", "sa_id_number" should consist of an empty value/string ''".

Previously when "id_type"="none", "sa_id_number had a value of ''none".