### PR TITLE
Add a flag for sending cases to Jembi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - pip install --upgrade pip
 
 install:
-  - pip install -e git+git://github.com/onaio/onapie.git#egg=onapie
+  - pip install -e git+git://github.com/onaio/onapie.git@bf9b905b1dd7db980ab4f7966fdbedf3cf816b29#egg=onapie
   - pip install coveralls
   - pip install flake8
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - pip install --upgrade pip
 
 install:
-  - pip install -e git+git://github.com/onaio/onapie.git@bf9b905b1dd7db980ab4f7966fdbedf3cf816b29#egg=onapie
+  - pip install -e git+git://github.com/onaio/onapie.git#egg=onapie
   - pip install coveralls
   - pip install flake8
   - pip install -r requirements-dev.txt

--- a/malaria24/ona/migrations/0026_reportedcase_jembi_alert_sent.py
+++ b/malaria24/ona/migrations/0026_reportedcase_jembi_alert_sent.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ona', '0025_smsevent'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='reportedcase',
+            name='jembi_alert_sent',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/malaria24/ona/migrations/0027_auto_20191101_1137.py
+++ b/malaria24/ona/migrations/0027_auto_20191101_1137.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ona', '0026_reportedcase_jembi_alert_sent'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reportedcase',
+            name='jembi_alert_sent',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -654,6 +654,7 @@ class ReportedCase(models.Model):
     digest = models.ForeignKey('Digest', null=True, blank=True)
     ehps = models.ManyToManyField('Actor', blank=True)
     form = models.ForeignKey('OnaForm', null=True, blank=True)
+    jembi_alert_sent = models.BooleanField(default=False)
 
     def normalize_msisdn(self, mobile_number):
         try:

--- a/malaria24/ona/models.py
+++ b/malaria24/ona/models.py
@@ -928,6 +928,8 @@ class SMSEvent(models.Model):
 def new_case_alert_jembi(sender, instance, created, **kwargs):
     if not created:
         return
+    if not settings.FORWARD_TO_JEMBI:
+        return
 
     alert_jembi(instance)
 

--- a/malaria24/ona/tasks.py
+++ b/malaria24/ona/tasks.py
@@ -149,6 +149,8 @@ def compile_and_send_jembi(case_pk):
     auth = HTTPBasicAuth(settings.JEMBI_USERNAME, settings.JEMBI_PASSWORD)
     r = requests.post(api_url, json=case_dictionary, auth=auth)
     r.raise_for_status()
+    case.jembi_alert_sent = True
+    case.save()
 
 
 @celery_app.task(ignore_result=True)

--- a/malaria24/ona/tests/test_admin.py
+++ b/malaria24/ona/tests/test_admin.py
@@ -1,0 +1,125 @@
+from django.contrib.auth.models import User
+from django.core import urlresolvers
+from django.db.models.signals import post_save
+from django.test import override_settings
+from mock import patch
+
+from malaria24.ona.models import (
+    ReportedCase,
+    new_case_alert_ehps,
+    new_case_alert_mis, new_case_alert_jembi)
+
+from .base import MalariaTestCase
+
+
+class ReportedCaseAdminTest(MalariaTestCase):
+    def setUp(self):
+        super(ReportedCaseAdminTest, self).setUp()
+        post_save.disconnect(
+            new_case_alert_ehps, sender=ReportedCase)
+        post_save.disconnect(
+            new_case_alert_mis, sender=ReportedCase)
+        post_save.disconnect(
+            new_case_alert_jembi, sender=ReportedCase)
+        User.objects.create_superuser(
+            username='test',
+            password='test',
+            email='test@test.com'
+        )
+        self.client.login(username='test', password='test')
+
+    def tearDown(self):
+        super(ReportedCaseAdminTest, self).tearDown()
+        post_save.connect(
+            new_case_alert_ehps, sender=ReportedCase)
+        post_save.connect(
+            new_case_alert_mis, sender=ReportedCase)
+        post_save.connect(
+            new_case_alert_jembi, sender=ReportedCase)
+
+    @override_settings(FORWARD_TO_JEMBI=False)
+    @patch('malaria24.ona.tasks.compile_and_send_jembi.delay')
+    def test_setting_disables_send_to_jembi(self, mock_task):
+        case = self.mk_case(first_name="John", last_name="Day", gender="male",
+                            msisdn="0711111111", landmark_description="None",
+                            id_type="said", case_number="20171214-123456-42",
+                            abroad="No", locality="None",
+                            reported_by="+27721111111",
+                            sa_id_number="5608071111083",
+                            landmark="School", facility_code="123456")
+        case.save()
+        case.digest = None
+        data = {
+            'action': 'send_jembi_alert',
+            '_selected_action': [case.pk]
+        }
+        list_url = urlresolvers.reverse('admin:ona_reportedcase_changelist')
+        response = self.client.post(list_url, data, follow=True)
+        mock_task.not_called()
+        self.assertContains(response, "Sending to Jembi currently disabled.")
+
+    @patch('malaria24.ona.tasks.compile_and_send_jembi.delay')
+    def test_only_unsent_cases_sent_to_jembi(self, mock_task):
+        case1 = self.mk_case(first_name="John", last_name="Day", gender="male",
+                             msisdn="0711111111", landmark_description="None",
+                             id_type="said", case_number="20171214-123456-42",
+                             abroad="No", locality="None",
+                             reported_by="+27721111111",
+                             sa_id_number="5608071111083",
+                             landmark="School", facility_code="123456",
+                             jembi_alert_sent=True)
+        case2 = self.mk_case(first_name="Mark", last_name="Day", gender="male",
+                             msisdn="0711111112", landmark_description="None",
+                             id_type="said", case_number="20171214-123456-56",
+                             abroad="No", locality="None",
+                             reported_by="+27721111112",
+                             sa_id_number="5610031111083",
+                             landmark="School", facility_code="123456")
+        case1.save()
+        case2.save()
+        data = {
+            'action': 'send_jembi_alert',
+            '_selected_action': [case1.pk, case2.pk]
+        }
+        list_url = urlresolvers.reverse('admin:ona_reportedcase_changelist')
+        response = self.client.post(list_url, data, follow=True)
+        mock_task.assert_called_with(case2.pk)
+        self.assertContains(response,
+                            "Forwarding all unsent cases to Jembi (total 1).")
+
+    @patch('malaria24.ona.tasks.compile_and_send_jembi.delay')
+    def test_task_called_for_each_selected_unsent_case(self, mock_task):
+        case1 = self.mk_case(first_name="John", last_name="Day", gender="male",
+                             msisdn="0711111111", landmark_description="None",
+                             id_type="said", case_number="20171214-123456-42",
+                             abroad="No", locality="None",
+                             reported_by="+27721111111",
+                             sa_id_number="5608071111083",
+                             landmark="School", facility_code="123456")
+        case2 = self.mk_case(first_name="Mark", last_name="Day", gender="male",
+                             msisdn="0711111112", landmark_description="None",
+                             id_type="said", case_number="20171214-123456-56",
+                             abroad="No", locality="None",
+                             reported_by="+27721111112",
+                             sa_id_number="5610031111083",
+                             landmark="School", facility_code="123456")
+        case3 = self.mk_case(first_name="Luke", last_name="Day", gender="male",
+                             msisdn="0711111113", landmark_description="None",
+                             id_type="said", case_number="20171214-123456-64",
+                             abroad="No", locality="None",
+                             reported_by="+27721111113",
+                             sa_id_number="8112051111083",
+                             landmark="School", facility_code="123456")
+        case1.save()
+        case2.save()
+        case3.save()
+        data = {
+            'action': 'send_jembi_alert',
+            '_selected_action': [case1.pk, case2.pk]
+        }
+        list_url = urlresolvers.reverse('admin:ona_reportedcase_changelist')
+        response = self.client.post(list_url, data, follow=True)
+        mock_task.assert_any_call(case1.pk)
+        mock_task.assert_any_call(case2.pk)
+        self.assertContains(response,
+                            "Forwarding all unsent cases to Jembi (total 2).")

--- a/malaria24/ona/tests/test_models.py
+++ b/malaria24/ona/tests/test_models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core import mail
 from django.db.models.signals import post_save
 from django.test import override_settings

--- a/malaria24/ona/tests/test_models.py
+++ b/malaria24/ona/tests/test_models.py
@@ -442,12 +442,16 @@ class DigestTest(MalariaTestCase):
         post_save.disconnect(new_case_alert_ehps, sender=ReportedCase)
         post_save.disconnect(
             new_case_alert_case_investigators, sender=ReportedCase)
+        post_save.disconnect(
+            new_case_alert_jembi, sender=ReportedCase)
 
     def tearDown(self):
         super(DigestTest, self).tearDown()
         post_save.connect(new_case_alert_ehps, sender=ReportedCase)
         post_save.connect(
             new_case_alert_case_investigators, sender=ReportedCase)
+        post_save.connect(
+            new_case_alert_jembi, sender=ReportedCase)
 
     def get_week(self, cases):
         test_cases = ReportedCase.objects.all().order_by("create_date_time")

--- a/malaria24/ona/tests/test_tasks.py
+++ b/malaria24/ona/tests/test_tasks.py
@@ -15,7 +15,7 @@ from rest_framework.authtoken.models import Token
 from malaria24.ona.models import (
     ReportedCase, new_case_alert_ehps, MIS, MANAGER_DISTRICT, MANAGER_NATIONAL,
     MANAGER_PROVINCIAL, OnaForm, Facility, SMS, DistrictDigest,
-    NationalDigest, ProvincialDigest)
+    NationalDigest, ProvincialDigest, new_case_alert_jembi)
 from malaria24.ona.tasks import (
     ona_fetch_reported_cases, compile_and_send_digest_email,
     compile_and_send_jembi, ona_fetch_forms, send_sms)
@@ -40,6 +40,7 @@ class OnaTest(MalariaTestCase):
                       body=pkg_resources.resource_string(
                           'malaria24', 'ona/fixtures/responses/forms.json'))
         post_save.disconnect(new_case_alert_ehps, sender=ReportedCase)
+        post_save.disconnect(new_case_alert_jembi, sender=ReportedCase)
         self.complete_url = settings.JEMBI_URL
         self.username = settings.JEMBI_USERNAME
         self.password = settings.JEMBI_PASSWORD
@@ -48,6 +49,8 @@ class OnaTest(MalariaTestCase):
         super(OnaTest, self).tearDown()
         post_save.connect(
             new_case_alert_ehps, sender=ReportedCase)
+        post_save.connect(
+            new_case_alert_jembi, sender=ReportedCase)
 
     @responses.activate
     def test_ona_fetch_reported_cases_task(self):
@@ -504,6 +507,9 @@ class OnaTest(MalariaTestCase):
                 case.get_data()
             )
         )
+
+        compile_and_send_jembi(case.pk)
+
         auth_headers = ('Basic ' +
                         b64encode("{0}:{1}".format(settings.JEMBI_USERNAME,
                                                    settings.JEMBI_PASSWORD)))

--- a/malaria24/ona/tests/test_tasks.py
+++ b/malaria24/ona/tests/test_tasks.py
@@ -499,6 +499,7 @@ class OnaTest(MalariaTestCase):
                             date_of_birth="1995-01-01")
         case.save()
         case.digest = None
+        self.assertFalse(case.jembi_alert_sent)
         responses.add(
             responses.POST,
             settings.JEMBI_URL,
@@ -535,6 +536,8 @@ class OnaTest(MalariaTestCase):
         self.assertEqual(data['locality'], 'None')
         self.assertEqual(data['landmark'], 'School')
         self.assertEqual(data['facility_code'], '123456')
+        case.refresh_from_db()
+        self.assertTrue(case.jembi_alert_sent)
 
     @responses.activate
     def test_send_jembi(self):
@@ -550,6 +553,7 @@ class OnaTest(MalariaTestCase):
                             landmark="School", facility_code="123456")
         case.save()
         case.digest = None
+        self.assertFalse(case.jembi_alert_sent)
         responses.add(
             responses.POST,
             settings.JEMBI_URL,
@@ -560,3 +564,5 @@ class OnaTest(MalariaTestCase):
         )
         with self.assertRaises(requests.HTTPError):
             compile_and_send_jembi(case.pk)
+        case.refresh_from_db()
+        self.assertFalse(case.jembi_alert_sent)

--- a/malaria24/settings/base.py
+++ b/malaria24/settings/base.py
@@ -122,6 +122,8 @@ CELERYBEAT_SCHEDULE = {
 DEFAULT_FROM_EMAIL = 'MalariaConnect <malaria24@praekelt.com>'
 
 # JEMBI settings
+# Send to them by default
+FORWARD_TO_JEMBI = environ.get('FORWARD_TO_JEMBI', 'true').lower() == 'true'
 JEMBI_URL = environ.get('JEMBI_URL') or 'http://jembi.org/malaria24'
 JEMBI_USERNAME = environ.get('JEMBI_USERNAME') or 'fake@example.com'
 JEMBI_PASSWORD = environ.get('JEMBI_PASSWORD') or 'not_a_real_password'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ djangorestframework==3.3.2
 pyopenssl==17.5.0
 ndg-httpsclient==0.4.3
 pyasn1==0.4.2
-requests
+requests>=2.4.2
 psycopg2


### PR DESCRIPTION
We want to be able to turn off sending events to Jembi in case they can't receive them.
This adds a flag to do that and also adds an admin action that enables us to send any unsent events in the event the service comes back up.