### PR TITLE
Upgrade to Django 1.11.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-Django==1.9
+Django==1.10.8
 django-appconf==1.0.3
 django-compressor==3.1
-django-taggit==0.24.0
+django-taggit==0.22.2
+django-modelcluster==3.1
 celery==3.1.18
 redis==3.5.3
 go_http==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-Django==1.10.8
+Django==1.11.29
 django-appconf==1.0.3
 django-compressor==3.1
 django-taggit==0.22.2
-django-modelcluster==3.1
 celery==3.1.18
 redis==3.5.3
 go_http==0.3.2


### PR DESCRIPTION
Upgrade for 1.11.29

Note: Removed the `django-modelcluster` in requirements as I forgot it was a step in the README and added it in. Because it is installed last, I'm not sure if there are implications with the installation order, I can add it to the requirements.txt in future upgrades