### PR TITLE
admin_static tag deprecated in favour of static

### DIFF
--- a/malaria24/ona/templates/admin/ona/facility/change_list.html
+++ b/malaria24/ona/templates/admin/ona/facility/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_urls admin_static admin_list %}
+{% load i18n admin_urls static admin_list %}
 
 {% block object-tools-items %}
 <li>

--- a/malaria24/ona/templates/ona/upload_facility_codes.html
+++ b/malaria24/ona/templates/ona/upload_facility_codes.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls admin_static admin_modify %}
+{% load i18n admin_urls admin_modify static %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
The `staticfiles` and `admin_static` template tag libraries will be removed. (https://docs.djangoproject.com/en/dev/internals/deprecation/)
`RemovedInDjango30Warning: {% load admin_static %} is deprecated in favor of {% load static %}`

`admin_static` was missed in the upgrade to Django 3, only `load_static` was replaced.