### PR TITLE
Update facility upload to handle CSVs and JSON within the view

### DIFF
--- a/malaria24/ona/admin.py
+++ b/malaria24/ona/admin.py
@@ -234,7 +234,9 @@ class FacilityAdmin(admin.ModelAdmin):
             if form.is_valid():
                 file = form.cleaned_data['upload'].read().decode('utf-8')
 
-                if form.cleaned_data['upload'].name.endswith('.csv'):
+                try:
+                    file_content_json = json.loads(file)
+                except json.JSONDecodeError:
                     string_io_file = io.StringIO(file)
                     next(string_io_file, None)
                     file_content_json = list(csv.DictReader(
@@ -249,9 +251,6 @@ class FacilityAdmin(admin.ModelAdmin):
                         ],
                         delimiter=',',
                     ))
-
-                if form.cleaned_data['upload'].name.endswith('.json'):
-                    file_content_json = json.loads(file)
 
                 import_facilities.delay(
                     file_content_json,

--- a/malaria24/ona/admin.py
+++ b/malaria24/ona/admin.py
@@ -238,17 +238,8 @@ class FacilityAdmin(admin.ModelAdmin):
                     file_content_json = json.loads(file)
                 except json.JSONDecodeError:
                     string_io_file = io.StringIO(file)
-                    next(string_io_file, None)
                     file_content_json = list(csv.DictReader(
                         string_io_file,
-                        fieldnames=[
-                            "FacCode",
-                            "Facility",
-                            "Province",
-                            "District",
-                            "Sub-District (Locality)",
-                            "Phase",
-                        ],
                         delimiter=',',
                     ))
 

--- a/malaria24/ona/tasks.py
+++ b/malaria24/ona/tasks.py
@@ -186,8 +186,7 @@ def compile_and_send_digest_email():
 
 
 @celery_app.task(ignore_result=True)
-def import_facilities(json_data, wipe, email_address):
-    data = json.loads(json_data)
+def import_facilities(data, wipe, email_address):
     if wipe:
         Facility.objects.all().delete()
 


### PR DESCRIPTION
During QA the bulk uploading of facilities in a CSV was tested not ok. 
On inspection, the CSVs were not being handled. 

It was also discovered that there was no indication to the headers required for CSV (or the JSON keys), this was added into a help string on the facilities page (this is pretty ugly so I am open to other suggestions but I will need some guidance) 
The JSON was also being handled in the celery task rather than in the view, @KaitCrawford and I decided it would be best for all of this to be handled in the view for facility upload. The initial solution was to have a separate function in tasks and handle the file there. 

